### PR TITLE
Change how menu and splash image interact, add proptype validation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,9 @@ require('dotenv').config({
     path: `.env.${process.env.NODE_ENV}`
 });
 
+/* eslint-disable-next-line no-undef */
+Element = typeof Element === 'undefined' ? function() {} : Element;
+
 exports.onCreateNode = ({ node, actions, getNode }) => {
     const { createNodeField } = actions;
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,9 +4,6 @@ require('dotenv').config({
     path: `.env.${process.env.NODE_ENV}`
 });
 
-/* eslint-disable-next-line no-undef */
-Element = typeof Element === 'undefined' ? function() {} : Element;
-
 exports.onCreateNode = ({ node, actions, getNode }) => {
     const { createNodeField } = actions;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "gatsby-source-filesystem": "^2.3.12",
         "gatsby-transformer-remark": "^2.0.0",
         "gatsby-transformer-sharp": "^2.0.0",
-        "lodash": "^4.15.0",
         "prismjs": "^1.20.0",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",

--- a/src/components/Body/index.module.css
+++ b/src/components/Body/index.module.css
@@ -1,5 +1,5 @@
 .container {
-    margin: 200px 1rem 1rem 1rem;
+    margin: 1rem;
     background-color: #2A2A2A;
     padding: 2rem 1rem;
 }

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -66,6 +66,13 @@ export default class Menu extends React.Component {
 }
 
 Menu.propTypes = {
-    visiblity: PropTypes.string.isRequired,
-    path: PropTypes.string.isRequired
+    visiblity: PropTypes.string,
+    path: PropTypes.string.isRequired,
+    // eslint-disable-next-line no-undef
+    menuRef: PropTypes.shape({ current: PropTypes.instanceOf(HTMLElement) })
+};
+
+Menu.defaultProps = {
+    visiblity: 'visible',
+    menuRef: React.createRef()
 };

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -39,6 +39,7 @@ export default class Menu extends React.Component {
                 className={`title-font ${css.container} ${
                     css[this.props.visiblity]
                 }`}
+                ref={this.props.menuRef}
             >
                 {this.getCorrectHeaderTag()}
                 <h2

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -68,7 +68,7 @@ export default class Menu extends React.Component {
 Menu.propTypes = {
     visiblity: PropTypes.string,
     path: PropTypes.string.isRequired,
-    menuRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+    menuRef: PropTypes.shape({ current: null })
 };
 
 Menu.defaultProps = {

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -68,8 +68,7 @@ export default class Menu extends React.Component {
 Menu.propTypes = {
     visiblity: PropTypes.string,
     path: PropTypes.string.isRequired,
-    // eslint-disable-next-line no-undef
-    menuRef: PropTypes.shape({ current: PropTypes.instanceOf(HTMLElement) })
+    menuRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 };
 
 Menu.defaultProps = {

--- a/src/components/Menu/index.module.css
+++ b/src/components/Menu/index.module.css
@@ -1,7 +1,4 @@
 .container {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     color: white;
     transition: opacity 0.5s linear;

--- a/src/components/MobileMenu/index.module.css
+++ b/src/components/MobileMenu/index.module.css
@@ -7,6 +7,7 @@
     /* add slide open effect for menu */
     transition: height 0.3s linear;
     overflow: hidden; 
+    z-index: 1;
 
     display: flex;
     flex-direction: column;
@@ -33,7 +34,6 @@
 
 .visible {
     height: 100vh;
-    z-index: 1000;
 }
 
 

--- a/src/components/MobileMenu/index.module.css
+++ b/src/components/MobileMenu/index.module.css
@@ -33,6 +33,7 @@
 
 .visible {
     height: 100vh;
+    z-index: 1000;
 }
 
 

--- a/src/components/splash/SplashImage/index.jsx
+++ b/src/components/splash/SplashImage/index.jsx
@@ -41,6 +41,8 @@ export default function SplashImage(props) {
     );
 }
 
+
 SplashImage.propTypes = {
-    height: PropTypes.string.isRequired
+    height: PropTypes.string.isRequired,
+    visiblity: PropTypes.string.isRequired
 };

--- a/src/components/splash/SplashImage/index.jsx
+++ b/src/components/splash/SplashImage/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { graphql, useStaticQuery } from 'gatsby';
 import Img from 'gatsby-image';
 import css from './index.module.css';
@@ -7,7 +8,7 @@ export default function SplashImage(props) {
     const data = useStaticQuery(
         graphql`
             query {
-                allFile(filter: { relativePath: { eq: "splash-image.jpg" } }) {
+                allFile(filter: { relativePath: { eq: "splash-image2.jpg" } }) {
                     edges {
                         node {
                             absolutePath
@@ -25,13 +26,21 @@ export default function SplashImage(props) {
     );
 
     return (
-        <div id="SplashImage" className={css.container}>
+        <div
+            id="SplashImage"
+            className={css.container}
+            style={{ height: props.height }}
+        >
             <Img
                 className={`${css.image} ${css[props.visiblity]}`}
                 height="100vh"
-                style={{ position: 'static' }}
+                style={{ width: '100%' }}
                 fluid={data.allFile.edges[0].node.childImageSharp.fluid}
             />
         </div>
     );
 }
+
+SplashImage.propTypes = {
+    height: PropTypes.string.isRequired
+};

--- a/src/components/splash/SplashImage/index.module.css
+++ b/src/components/splash/SplashImage/index.module.css
@@ -3,7 +3,6 @@
   justify-content: center;
   width: 100vw;
   overflow: hidden;
-  z-index: -99;
   background-color: #000000;
 }
 

--- a/src/components/splash/SplashImage/index.module.css
+++ b/src/components/splash/SplashImage/index.module.css
@@ -1,10 +1,6 @@
 .container {
-  position: absolute;
-  top: 0;
-  left: 0;
   display: flex;
   justify-content: center;
-  height: 100vh;
   width: 100vw;
   overflow: hidden;
   z-index: -99;
@@ -12,7 +8,7 @@
 }
 
 .image {
-  height: 100vh;
+  height: 100%;
   transition: opacity 0.5s linear;
 }
 

--- a/src/pages/biography.jsx
+++ b/src/pages/biography.jsx
@@ -3,11 +3,11 @@ import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
 
-export default function Biography() {
+export default function Biography(props) {
     return (
         <div>
             <Template>
-                <Menu />
+                <Menu path={props.location.pathname} />
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Biography</h1>
                     <p>He&apos;s a big dog baritone</p>

--- a/src/pages/biography.jsx
+++ b/src/pages/biography.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
@@ -16,3 +17,9 @@ export default function Biography(props) {
         </div>
     );
 }
+
+Biography.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired
+};

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
@@ -21,3 +22,9 @@ export default function Contact(props) {
         </div>
     );
 }
+
+Contact.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired
+};

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -4,11 +4,11 @@ import Menu from '../components/Menu';
 import Body from '../components/Body';
 import ContactForm from '../components/ContactForm';
 
-export default function Contact() {
+export default function Contact(props) {
     return (
         <div>
             <Template>
-                <Menu />
+                <Menu path={props.location.pathname} />
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Contact</h1>
                     <p>

--- a/src/pages/events.jsx
+++ b/src/pages/events.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
@@ -65,3 +66,26 @@ export const eventsQuery = graphql`
         }
     }
 `;
+
+Events.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired,
+    data: PropTypes.shape({
+        allMarkdownRemark: PropTypes.shape({
+            edges: PropTypes.arrayOf(
+                PropTypes.shape({
+                    frontmatter: PropTypes.shape({
+                        name: PropTypes.string,
+                        venue: PropTypes.string,
+                        url: PropTypes.string
+                    }),
+                    fields: PropTypes.shape({
+                        slug: PropTypes.string
+                    }),
+                    html: PropTypes.string
+                })
+            )
+        })
+    }).isRequired
+};

--- a/src/pages/events.jsx
+++ b/src/pages/events.jsx
@@ -11,7 +11,7 @@ function Events(props) {
     return (
         <div>
             <Template>
-                <Menu />
+                <Menu path={props.location.pathname} />
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Events</h1>
                     {events.map(({ node }) => {

--- a/src/pages/events.jsx
+++ b/src/pages/events.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
-import get from 'lodash/get';
 import { graphql } from 'gatsby';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
 
 function Events(props) {
-    const events = get(props, 'data.allMarkdownRemark.edges');
+    const events = props.data.allMarkdownRemark.edges;
 
     return (
         <div>
@@ -16,8 +15,8 @@ function Events(props) {
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Events</h1>
                     {events.map(({ node }) => {
-                        const title = get(node, 'frontmatter.name');
-                        const venue = get(node, 'frontmatter.venue');
+                        const title = node.frontmatter.name;
+                        const venue = node.frontmatter.venue;
                         return (
                             <div key={node.fields.slug}>
                                 <h3>{title}</h3>

--- a/src/pages/gallery.jsx
+++ b/src/pages/gallery.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
@@ -16,3 +17,9 @@ export default function Gallery(props) {
         </div>
     );
 }
+
+Gallery.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired
+};

--- a/src/pages/gallery.jsx
+++ b/src/pages/gallery.jsx
@@ -3,11 +3,11 @@ import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
 
-export default function Gallery() {
+export default function Gallery(props) {
     return (
         <div>
             <Template>
-                <Menu />
+                <Menu path={props.location.pathname} />
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Gallery</h1>
                     <p>Look at the big dog baritone</p>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -27,7 +27,9 @@ class SplashPage extends React.Component {
             const menuHeight = this.menuRef.current.clientHeight;
             // eslint-disable-next-line no-undef
             const splashImageHeight = window.visualViewport.height - menuHeight;
-            this.setState({ imageHeight: `${splashImageHeight}px` });
+            this.setState({
+                imageHeight: `${splashImageHeight}px`
+            });
         }
     };
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SplashLayout from '../layouts/SplashLayout';
 import SplashImage from '../components/splash/SplashImage';
 import Menu from '../components/Menu';
@@ -21,8 +22,10 @@ class SplashPage extends React.Component {
     }
 
     calculateSplashImageHeight = () => {
+        // eslint-disable-next-line no-undef
         if (window) {
             const menuHeight = this.menuRef.current.clientHeight;
+            // eslint-disable-next-line no-undef
             const splashImageHeight = window.visualViewport.height - menuHeight;
             this.setState({ imageHeight: `${splashImageHeight}px` });
         }
@@ -48,3 +51,9 @@ class SplashPage extends React.Component {
 }
 
 export default SplashPage;
+
+SplashPage.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired
+};

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -6,25 +6,40 @@ import Menu from '../components/Menu';
 class SplashPage extends React.Component {
     constructor(props) {
         super(props);
+        this.menuRef = React.createRef();
         this.state = {
-            visibility: 'hidden'
+            visibility: 'hidden',
+            imageHeight: '80vh'
         };
     }
 
     componentDidMount() {
+        this.calculateSplashImageHeight();
         setTimeout(() => {
             this.setState({ visibility: 'visible' });
         }, 20);
     }
 
+    calculateSplashImageHeight = () => {
+        if (window) {
+            const menuHeight = this.menuRef.current.clientHeight;
+            const splashImageHeight = window.visualViewport.height - menuHeight;
+            this.setState({ imageHeight: `${splashImageHeight}px` });
+        }
+    };
+
     render() {
         return (
             <div>
                 <SplashLayout>
-                    <SplashImage visiblity={this.state.visibility} />
                     <Menu
                         path={this.props.location.pathname}
                         visiblity={this.state.visibility}
+                        menuRef={this.menuRef}
+                    />
+                    <SplashImage
+                        visiblity={this.state.visibility}
+                        height={this.state.imageHeight}
                     />
                 </SplashLayout>
             </div>

--- a/src/pages/listen.jsx
+++ b/src/pages/listen.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
@@ -58,3 +59,23 @@ export const videosQuery = graphql`
         }
     }
 `;
+
+Listen.propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string
+    }).isRequired,
+    data: PropTypes.shape({
+        allMarkdownRemark: PropTypes.shape({
+            edges: PropTypes.arrayOf(
+                PropTypes.shape({
+                    frontmatter: PropTypes.shape({
+                        title: PropTypes.string.isRequired
+                    }),
+                    fields: PropTypes.shape({
+                        slug: PropTypes.string.isRequired
+                    })
+                })
+            )
+        })
+    }).isRequired
+};

--- a/src/pages/listen.jsx
+++ b/src/pages/listen.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 import { graphql } from 'gatsby';
-import get from 'lodash/get';
 import Template from '../layouts/Template';
 import Menu from '../components/Menu';
 import Body from '../components/Body';
 
 export default function Listen(props) {
-    const videos = get(props, 'data.allMarkdownRemark.edges');
+    const videos = props.data.allMarkdownRemark.edges;
 
     return (
         <div>
@@ -17,9 +16,9 @@ export default function Listen(props) {
                     <h1 className="title-font large-text">Listen</h1>
                     <div id="Videos">
                         {videos.map(({ node }) => {
-                            const title = get(node, 'frontmatter.title');
-                            const slug = get(node, 'fields.slug');
-                            const html = get(node, 'html');
+                            const title = node.frontmatter.title;
+                            const slug = node.fields.slug;
+                            const html = node.html;
 
                             return (
                                 <div key={slug}>

--- a/src/pages/listen.jsx
+++ b/src/pages/listen.jsx
@@ -11,7 +11,7 @@ export default function Listen(props) {
     return (
         <div>
             <Template>
-                <Menu />
+                <Menu path={props.location.pathname} />
                 <Body className="white center-text body-font">
                     <h1 className="title-font large-text">Listen</h1>
                     <div id="Videos">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
 body {
     background: black;
     font-family: sans-serif;
+    margin: 0;
 }
 
 .title-font {


### PR DESCRIPTION
# Description

Changes how the Menu component sits alongside the SplashImage or Body component beneath it. Old way was convoluted and due to working with Gatsby Images.

Introduces thorough proptype validation for all components, and adds absent props that were flying under the radar (e.g. no path being sent to Menu expect on splash page).